### PR TITLE
A new extension for MADE-VBS aerosols with chem_opt=3 (for chem_opt=108 in WRF-Chem)

### DIFF
--- a/external/tools/configure.f90
+++ b/external/tools/configure.f90
@@ -76,7 +76,7 @@ real              :: spike_tolerance = 1.5
 
 !!!!!
 integer :: io_status
-integer, parameter :: nMaxvar = 55
+integer, parameter :: nMaxvar = 58
 integer, dimension(nMaxvar) :: covar1, covar2, covar3, covar4, covar5 
 integer, dimension(nMaxvar) :: covar6, covar7, covar8, covar9, covar10
 integer, dimension(nMaxvar) :: covar11, covar12, covar13, covar14, covar15
@@ -88,6 +88,7 @@ integer, dimension(nMaxvar) :: covar36, covar37, covar38, covar39, covar40
 integer, dimension(nMaxvar) :: covar41, covar42, covar43, covar44, covar45
 integer, dimension(nMaxvar) :: covar46, covar47, covar48, covar49, covar50
 integer, dimension(nMaxvar) :: covar51, covar52, covar53, covar54, covar55
+integer, dimension(nMaxvar) :: covar56, covar57, covar58
 integer, dimension(nMaxvar) :: ncovar, nvarce1d, ncovar_row 
 integer, dimension(nMaxvar,nMaxvar) :: covar_ID, covar_ID2 
 character (len=32), dimension(nMaxvar) :: cv_list, cv_listu, tmp_list,  tmp_list2 
@@ -175,6 +176,9 @@ namelist /gen_be_info/ model, &
                    covar53, &
                    covar54, &
                    covar55, &
+                   covar56, &
+                   covar57, &
+                   covar58, &
                    use_chol_reg
       namelist /gen_be_bin/ bin_type, &
                    lat_min, &
@@ -215,6 +219,8 @@ contains
         NVARMAX = 42
       else if (chem_opt.eq.2) then 
         NVARMAX = 55
+      else if (chem_opt.eq.3) then     ! MADE-VBS (syha on Mar-17-2022)
+        NVARMAX = 58
       end if
 
       allocate( varname_all(NVARMAX) ) 
@@ -318,6 +324,53 @@ contains
      varname_all(54) = 'ps'
      varname_all(55) = 'vis'
      vardim_all(54:55) = 2 
+
+  else if (chem_opt.eq.3) then   ! MADE-VBS (syha on Mar-17-2022)
+     varname_all(18) = 'so4aj'
+     varname_all(19) = 'so4ai'
+     varname_all(20) = 'nh4aj'
+     varname_all(21) = 'nh4ai'
+     varname_all(22) = 'no3aj'
+     varname_all(23) = 'no3ai'
+     varname_all(24) = 'naaj'
+     varname_all(25) = 'naai'
+     varname_all(26) = 'claj'
+     varname_all(27) = 'clai'
+     varname_all(28) = 'asoa1j'
+     varname_all(29) = 'asoa1i'
+     varname_all(30) = 'asoa2j'
+     varname_all(31) = 'asoa2i'
+     varname_all(32) = 'asoa3j'
+     varname_all(33) = 'asoa3i'
+     varname_all(34) = 'asoa4j'
+     varname_all(35) = 'asoa4i'
+     varname_all(36) = 'bsoa1j'
+     varname_all(37) = 'bsoa1i'
+     varname_all(38) = 'bsoa2j'
+     varname_all(39) = 'bsoa2i'
+     varname_all(40) = 'bsoa3j'
+     varname_all(41) = 'bsoa3i'
+     varname_all(42) = 'bsoa4j'
+     varname_all(43) = 'bsoa4i'
+     varname_all(44) = 'orgpaj'
+     varname_all(45) = 'orgpai'
+     varname_all(46) = 'ecj'
+     varname_all(47) = 'eci'
+     varname_all(48) = 'p25j'
+     varname_all(49) = 'p25i'
+     varname_all(50) = 'antha'
+     varname_all(51) = 'seas'
+     varname_all(52) = 'soila'
+     varname_all(53) = 'so2'
+     varname_all(54) = 'no2'
+     varname_all(55) = 'o3'
+     varname_all(56) = 'co'
+     vardim_all(18:56) = 3
+
+     varname_all(57) = 'ps'
+     varname_all(58) = 'vis'
+     vardim_all(57:58) = 2
+
   end if
 
       jj = 0
@@ -459,9 +512,9 @@ contains
           write(*,*)'change the value in configure.f90'
           stop
        end if
-      
 
        ! initialisation of covar
+
        covar_ID(1,:) = covar1(:)
        !covar_ID(1,:) = -1 
        covar_ID(2,:) = covar2(:)
@@ -512,7 +565,7 @@ contains
        covar_ID(42,:) = covar42(:)
 
    end if
-   if (chem_opt.eq.2) then
+   if (chem_opt.ge.2) then
 
        covar_ID(43,:) = covar43(:)
        covar_ID(44,:) = covar44(:)
@@ -527,7 +580,14 @@ contains
        covar_ID(53,:) = covar53(:)
        covar_ID(54,:) = covar54(:)
        covar_ID(55,:) = covar55(:)
-  end if
+   end if
+
+   if (chem_opt.ge.3) then ! MADE-VBS (syha on Mar-17-2022)
+       covar_ID(56,:) = covar55(:)
+       covar_ID(57,:) = covar55(:)
+       covar_ID(58,:) = covar55(:)
+   end if
+
        covar_ID2 = covar_ID
 
        ! prepare for dimension purpose in alloc section

--- a/external/tools/io_input_model.f90
+++ b/external/tools/io_input_model.f90
@@ -689,6 +689,8 @@ module io_input_model
        nchem = 23
      else if (chem_opt.eq.2) then        !!! aero cv for MOSAIC + gas cv !!! 
        nchem = 36
+     else if (chem_opt.eq.3) then        !!! aero cv for MADE-VBS+gas cv !!! 
+       nchem = 39
      end if 
 
      allocate(varname_wrf(1:nchem))
@@ -823,6 +825,50 @@ module io_input_model
      varname_ind(34) = "no2"
      varname_ind(35) = "o3"
      varname_ind(36) = "co"
+
+     else if (chem_opt.eq.3) then  ! MADE-VBS (syha on Mar-17-2022)
+
+     varname_wrf(1)  = "so4aj"
+     varname_wrf(2)  = "so4ai"
+     varname_wrf(3)  = "nh4aj"
+     varname_wrf(4)  = "nh4ai"
+     varname_wrf(5)  = "no3aj"
+     varname_wrf(6)  = "no3ai"
+     varname_wrf(7)  = "naaj"
+     varname_wrf(8)  = "naai"
+     varname_wrf(9)  = "claj"
+     varname_wrf(10) = "clai"
+     varname_wrf(11) = "asoa1j"
+     varname_wrf(12) = "asoa1i"
+     varname_wrf(13) = "asoa2j"
+     varname_wrf(14) = "asoa2i"
+     varname_wrf(15) = "asoa3j"
+     varname_wrf(16) = "asoa3i"
+     varname_wrf(17) = "asoa4j"
+     varname_wrf(18) = "asoa4i"
+     varname_wrf(19) = "bsoa1j"
+     varname_wrf(20) = "bsoa1i"
+     varname_wrf(21) = "bsoa2j"
+     varname_wrf(22) = "bsoa2i"
+     varname_wrf(23) = "bsoa3j"
+     varname_wrf(24) = "bsoa3i"
+     varname_wrf(25) = "bsoa4j"
+     varname_wrf(26) = "bsoa4i"
+     varname_wrf(27) = "orgpaj"
+     varname_wrf(28) = "orgpai"
+     varname_wrf(29) = "ecj"
+     varname_wrf(30) = "eci"
+     varname_wrf(31) = "p25j"
+     varname_wrf(32) = "p25i"
+     varname_wrf(33) = "antha"
+     varname_wrf(34) = "seas"
+     varname_wrf(35) = "soila"
+     varname_wrf(36) = "so2"
+     varname_wrf(37) = "no2"
+     varname_wrf(38) = "o3"
+     varname_wrf(39) = "co"
+
+     varname_ind(1:39) = varname_wrf(1:39)
 
      end if
 

--- a/scripts/namelist.template.madevbs
+++ b/scripts/namelist.template.madevbs
@@ -1,0 +1,55 @@
+
+&gen_be_info
+model = 'WRF'
+application = 'WRFDA'
+be_method = '_BE_METHOD_',
+ne = _NE_,
+cut = 0, 0, 0, 0, 0, 0,
+use_mean_ens=.true.
+start_date = '_START_DATE_',
+end_date = '_END_DATE_',
+interval = _INTERVAL_,
+testing_eofs = .true.
+/
+
+&Gen_be_cv
+nb_cv = 45,
+chem_opt = 3,
+cv_list = 'u','v','t','rh',
+          'so4aj',  'so4ai',  'nh4aj',  'nh4ai',
+          'no3aj',  'no3ai',  'naaj',   'naai',
+          'asoa1j', 'asoa1i', 'asoa2j', 'asoa2i',
+          'asoa3j', 'asoa3i', 'asoa4j', 'asoa4i',
+          'bsoa1j', 'bsoa1i', 'bsoa2j', 'bsoa2i',
+          'bsoa3j', 'bsoa3i', 'bsoa4j', 'bsoa4i',
+          'orgpaj', 'orgpai', 'ecj',    'eci',
+          'p25j',   'p25i',   'antha',  'seas',
+          'soila',  'claj',   'clai',
+          'so2',    'no2',    'o3',     'co',
+          'w',      'ps',
+fft_method = 2,
+use_chol_reg = .false.
+/
+
+&gen_be_bin
+bin_type = 5,
+lat_min = 20.0,
+lat_max = 55.0,
+binwidth_lat = 5.0,
+hgt_min = 1000.0,
+hgt_max = 2000.0,
+binwidth_hgt = 1000.0,
+/
+
+&gen_be_lenscale
+data_on_levels = .false.
+vert_ls_method = 1,
+ls_method = 2,
+use_med_ls = .true.
+horizvar = 'correl',
+horizfunct = 'Gauss',
+stride = 1,
+n_smth_ls = 2,
+use_global_bin = .true.
+/
+


### PR DESCRIPTION
TYPE: New feature

KEYWARDS: GENBE_2.0, Chemical DA, 3DVAR

SOURCE: Soyoung Ha (MMM/NCAR)

DESCRIPTION OF CHANGES:

1. A new capability of computing background error covariance (be.dat) for chemical/aerosol data assimilation using the RACM/MADE-VBS scheme in WRF-Chem (chem_opt=108).
2. A new namelist option for "chem_opt" is added in &gen_be_cv: chem_opt=3 for RACM/MADE-VBS in WRF-Chem.

LIST OF MODIFIED/ADDED FILES:
M external/tools/configure.f90 
M external/tools/io_input_model.f90
A scripts/namelist.template.madevbs

TESTS CONDUCTED:
The code is successfully compiled with the intel/19.1.1 compiler and netcdf/4.8.1 on Cheyenne after manually changing the compilation option '-openmp' to '-qopenmp' in configure.gen_be.
The new option is well tested with chem_opt=3 under &gen_be_cv using namelist.template.madevbs.

Reference:
Ha, S., 2022: Implementation of aerosol data assimilation in WRFDA (v4.0.3) for WRF-Chem (v3.9.1) using the RACM/MADE-VBS scheme, Geosci. Model Dev., 15, 1769–1788, https://doi.org/10.5194/gmd-15-1769-2022.
